### PR TITLE
Additional fixes and testing/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,14 @@ resources out yourself.
 * mounted - If puppet should mount the volume. This only affects what puppet will do, and not what will be mounted at boot-time.
 * no_sync (Parameter) - An optimization in lvcreate, at least on Linux.
 * persistent (Parameter) - Set to true to make the block device persistent
+* poolmetadatasize (Parameter) - Change the size of the logical volume pool metadata
 * readahead (Parameter) - The readahead count to use for the new logical volume.
 * region_size (Parameter) - A mirror is divided into regions of this size (in MB), the mirror log uses this granularity to track which regions are in sync. CAN NOT BE CHANGED on already mirrored volume. Take your mirror size in terabytes and round up that number to the next power of 2, using that number as the -R argument.
 * size (Property) - The size of the logical volume. Set to undef to use all available space
 * size_is_minsize (Parameter) Default value: `:false` - Set to true if the ‘size’ parameter specified, is just the minimum size you need (if the LV found is larger then the size requests this is just logged not causing a FAIL)
 * stripes (Parameter) - The number of stripes to allocate for the new logical volume.
 * stripesize (Parameter) - The stripesize to use for the new logical volume.
+* thin (Parameter) - Default value: `:false` - Set to true to create a thin provisioned logical volume
 * volume_group (Parameter) - The volume group name associated with this logical volume. This will automatically set this volume group as a dependency, but it must be defined elsewhere using the volume_group resource type.
 
 ### physical_volume

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -52,7 +52,10 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     end
 
     def create
-        args = ['-n', @resource[:name]]
+        args = []
+
+        args.push('-n', @resource[:name]) unless @resource[:thin]
+
         if @resource[:size]
             args.push('--size', @resource[:size])
         elsif @resource[:initial_size]
@@ -76,7 +79,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
 
 	
 
-	if @resource[:poolmetadatasize]
+        if @resource[:poolmetadatasize]
             args.push('--poolmetadatasize', @resource[:poolmetadatasize])
         end
 
@@ -115,12 +118,10 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             args.push('--type', @resource[:type])
         end
 
-	if @resource[:thin]
+        if @resource[:thin]
             args.push('--thin')
-            # With thin-provisioned volumes, we can't use the name parameter
-            args = args.drop(2)
             args << @resource[:volume_group] + "/" + @resource[:name]
-	else
+        else
             args << @resource[:volume_group]
         end
         lvcreate(*args)

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:logical_volume) do
 
   ensurable
@@ -74,13 +76,9 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
-  newparam(:thin) do
+  newparam(:thin, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc "Set to true to create a thin provisioned logical volume"
-    validate do |value|
-      unless [:true, true, "true", :false, false, "false"].include?(value)
-        raise ArgumentError , "thin must be either be true or false"
-      end
-    end
+    defaultto false 
   end
 
   newparam(:poolmetadatasize) do

--- a/spec/unit/puppet/type/logical_volume_spec.rb
+++ b/spec/unit/puppet/type/logical_volume_spec.rb
@@ -12,6 +12,8 @@ describe Puppet::Type.type(:logical_volume) do
       :size_is_minsize => :false,
       :persistent => :false,
       :minor => 100,
+      :thin => false,
+      :poolmetadatasize => '10M',
     }
     stub_default_provider!
       end
@@ -46,6 +48,7 @@ describe Puppet::Type.type(:logical_volume) do
       with(valid_params)[:size].should == valid_params[:size]
     end
   end
+
 
   describe "when specifying the 'size_is_minsize' parameter" do
     it "should exist" do
@@ -88,6 +91,49 @@ describe Puppet::Type.type(:logical_volume) do
       end
     end
 
+  end
+
+  describe "when specifying the 'thin' parameter" do
+    it "should exist" do
+      @type.attrclass(:thin).should_not be_nil
+    end
+    it 'should support setting a value' do
+      with(valid_params)[:thin].should == valid_params[:thin]
+    end
+    it "should support 'true' as a value" do
+      with(valid_params.merge(:thin => :true)) do |resource|
+        resource[:thin].should == true
+        end
+      end
+    it "should support 'false' as a value" do
+      with(valid_params.merge(:thin => :false)) do |resource|
+        resource[:thin].should == false
+        end
+      end
+    it "should not support other values" do
+      specifying(valid_params.merge(:thin => :moep)).should raise_error(Puppet::Error)
+    end
+  end
+
+  describe "when specifying the 'poolmetadatasize' parameter" do
+    it "should exist" do
+      @type.attrclass(:poolmetadatasize).should_not be_nil
+    end
+    it 'should support setting a value' do
+      with(valid_params)[:poolmetadatasize].should == valid_params[:poolmetadatasize]
+    end
+
+    it 'should support K, M, G, T, P and E as extensions' do
+      ['K', 'M', 'G', 'T', 'P', 'E'].each do |ext|
+        with(valid_params.merge(:poolmetadatasize => "10#{ext}")) do |resource|
+          resource[:poolmetadatasize].should == "10#{ext}"
+        end
+      end
+    end
+
+    it "should not support other values" do
+      specifying(valid_params.merge(:poolmetadatasize => "100X")).should raise_error(Puppet::Error)
+    end
   end
 
   describe "when specifying the 'extents' parameter" do


### PR DESCRIPTION
This commit fixes the comments raised in PR/154 and adds testing and
documentation;
- Inherit the thin attribute from Puppet::Parameter::Boolean
- Conditionally add -n flag to provider args rather than drop later
- Fixed hard tab spaces in provider
- Added documentation for new attributes
- Added rspec tests
