### PR TITLE
Additional changes...

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ resources out yourself.
 * mounted - If puppet should mount the volume. This only affects what puppet will do, and not what will be mounted at boot-time.
 * no_sync (Parameter) - An optimization in lvcreate, at least on Linux.
 * persistent (Parameter) - Set to true to make the block device persistent
-* poolmetadatasize (Parameter) - Change the size of the logical volume pool metadata
+* poolmetadatasize (Parameter) - Set the initial size of the logical volume pool metadata on creation
 * readahead (Parameter) - The readahead count to use for the new logical volume.
 * region_size (Parameter) - A mirror is divided into regions of this size (in MB), the mirror log uses this granularity to track which regions are in sync. CAN NOT BE CHANGED on already mirrored volume. Take your mirror size in terabytes and round up that number to the next power of 2, using that number as the -R argument.
 * size (Property) - The size of the logical volume. Set to undef to use all available space

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ resources out yourself.
 * size_is_minsize (Parameter) Default value: `:false` - Set to true if the ‘size’ parameter specified, is just the minimum size you need (if the LV found is larger then the size requests this is just logged not causing a FAIL)
 * stripes (Parameter) - The number of stripes to allocate for the new logical volume.
 * stripesize (Parameter) - The stripesize to use for the new logical volume.
-* thin (Parameter) - Default value: `:false` - Set to true to create a thin provisioned logical volume
+* thinpool (Parameter) - Default value: `:false` - Set to true to create a thin pool
 * volume_group (Parameter) - The volume group name associated with this logical volume. This will automatically set this volume group as a dependency, but it must be defined elsewhere using the volume_group resource type.
 
 ### physical_volume

--- a/lib/puppet/provider/logical_volume/lvm.rb
+++ b/lib/puppet/provider/logical_volume/lvm.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
     def create
         args = []
 
-        args.push('-n', @resource[:name]) unless @resource[:thin]
+        args.push('-n', @resource[:name]) unless @resource[:thinpool]
 
         if @resource[:size]
             args.push('--size', @resource[:size])
@@ -118,7 +118,7 @@ Puppet::Type.type(:logical_volume).provide :lvm do
             args.push('--type', @resource[:type])
         end
 
-        if @resource[:thin]
+        if @resource[:thinpool]
             args.push('--thin')
             args << @resource[:volume_group] + "/" + @resource[:name]
         else

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -76,8 +76,8 @@ Puppet::Type.newtype(:logical_volume) do
     end
   end
 
-  newparam(:thin, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-    desc "Set to true to create a thin provisioned logical volume"
+  newparam(:thinpool, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Set to true to create a thin pool"
     defaultto false 
   end
 

--- a/lib/puppet/type/logical_volume.rb
+++ b/lib/puppet/type/logical_volume.rb
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:logical_volume) do
     desc "Change the size of logical volume pool metadata"
     validate do |value|
       unless value =~ /^[0-9]+(\.[0-9]+)?[KMGTPE]/i
-        raise ArgumentError , "#{value} is not a valid logical volume size"
+        raise ArgumentError , "#{value} is not a valid size for pool metadata"
       end
     end
   end

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -21,7 +21,7 @@ define lvm::logical_volume (
   $range             = undef,
   $size_is_minsize   = undef,
   $type              = undef,
-  $thin              = undef,
+  $thinpool          = undef,
   $poolmetadatasize  = undef,
 ) {
 
@@ -84,7 +84,7 @@ define lvm::logical_volume (
     range            => $range,
     size_is_minsize  => $size_is_minsize,
     type             => $type,
-    thin             => $thin,
+    thinpool         => $thin,
     poolmetadatasize => $poolmetadatasize,
   }
 

--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -21,6 +21,8 @@ define lvm::logical_volume (
   $range             = undef,
   $size_is_minsize   = undef,
   $type              = undef,
+  $thin              = undef,
+  $poolmetadatasize  = undef,
 ) {
 
   validate_bool($mountpath_require)
@@ -71,17 +73,19 @@ define lvm::logical_volume (
   }
 
   logical_volume { $name:
-    ensure          => $ensure,
-    volume_group    => $volume_group,
-    size            => $size,
-    initial_size    => $initial_size,
-    stripes         => $stripes,
-    stripesize      => $stripesize,
-    readahead       => $readahead,
-    extents         => $extents,
-    range           => $range,
-    size_is_minsize => $size_is_minsize,
-    type            => $type
+    ensure           => $ensure,
+    volume_group     => $volume_group,
+    size             => $size,
+    initial_size     => $initial_size,
+    stripes          => $stripes,
+    stripesize       => $stripesize,
+    readahead        => $readahead,
+    extents          => $extents,
+    range            => $range,
+    size_is_minsize  => $size_is_minsize,
+    type             => $type,
+    thin             => $thin,
+    poolmetadatasize => $poolmetadatasize,
   }
 
   if $createfs {

--- a/spec/unit/puppet/type/logical_volume_spec.rb
+++ b/spec/unit/puppet/type/logical_volume_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:logical_volume) do
       :size_is_minsize => :false,
       :persistent => :false,
       :minor => 100,
-      :thin => false,
+      :thinpool => false,
       :poolmetadatasize => '10M',
     }
     stub_default_provider!
@@ -93,25 +93,25 @@ describe Puppet::Type.type(:logical_volume) do
 
   end
 
-  describe "when specifying the 'thin' parameter" do
+  describe "when specifying the 'thinpool' parameter" do
     it "should exist" do
-      @type.attrclass(:thin).should_not be_nil
+      @type.attrclass(:thinpool).should_not be_nil
     end
     it 'should support setting a value' do
-      with(valid_params)[:thin].should == valid_params[:thin]
+      with(valid_params)[:thinpool].should == valid_params[:thinpool]
     end
     it "should support 'true' as a value" do
-      with(valid_params.merge(:thin => :true)) do |resource|
-        resource[:thin].should == true
+      with(valid_params.merge(:thinpool => :true)) do |resource|
+        resource[:thinpool].should == true
         end
       end
     it "should support 'false' as a value" do
-      with(valid_params.merge(:thin => :false)) do |resource|
-        resource[:thin].should == false
+      with(valid_params.merge(:thinpool => :false)) do |resource|
+        resource[:thinpool].should == false
         end
       end
     it "should not support other values" do
-      specifying(valid_params.merge(:thin => :moep)).should raise_error(Puppet::Error)
+      specifying(valid_params.merge(:thinpool => :moep)).should raise_error(Puppet::Error)
     end
   end
 


### PR DESCRIPTION
### Changed attribute name

After a long discussion with @vinzentm we've renamed the attribute - I'll follow this up with more explanation on the original ticket, but this makes sense for probable future planning
### Added attributes to defined resource type

This enabled the new `thinpool` and `poolmetadatasize` attributes to be set from the `lvm::logical_volume` defined resource type, thus enabling this configuration to be possible from hiera...etc
