### PR TITLE
changed $thin to $thinpool, ommitted after attribute rename

### DIFF
--- a/manifests/logical_volume.pp
+++ b/manifests/logical_volume.pp
@@ -89,7 +89,7 @@ define lvm::logical_volume (
     range            => $range,
     size_is_minsize  => $size_is_minsize,
     type             => $type,
-    thinpool         => $thin,
+    thinpool         => $thinpool,
     poolmetadatasize => $poolmetadatasize,
     mirror           => $mirror,
     mirrorlog        => $mirrorlog,


### PR DESCRIPTION
Sorry - last one (I hope) forgot to change this variable after renaming the attribute......

Spotted this morning in the travis checks.
